### PR TITLE
Fix toggle button overlaying activation key input

### DIFF
--- a/templates/premium-status.html
+++ b/templates/premium-status.html
@@ -121,9 +121,9 @@
                    style="width: 100%; padding: 12px 50px 12px 16px; border: 1px solid #cbd5e1; border-radius: 6px; font-size: 14px; font-family: 'SF Mono', 'Monaco', 'Courier New', monospace; letter-spacing: 1px; box-sizing: border-box;">
             
             <!-- Toggle visibility button -->
-            <button type="button" 
+            <button type="button"
                     id="toggle-key-visibility"
-                    style="position: absolute; right: 8px; top: 50%; transform: translateY(-50%); background: none; border: none; color: #64748b; cursor: pointer; padding: 8px; border-radius: 4px; transition: all 0.2s ease;"
+                    style="position: absolute; right: 8px; top: 50%; transform: translateY(-50%); background: none; border: none; color: #64748b; cursor: pointer; padding: 8px; border-radius: 4px; transition: all 0.2s ease; display: inline-flex; align-items: center; justify-content: center; width: auto; height: auto; z-index: 1;"
                     title="Show/Hide activation key">
                 <i class="fas fa-eye" id="visibility-icon"></i>
             </button>
@@ -243,6 +243,16 @@
 #toggle-key-visibility:hover {
     background-color: #f1f5f9;
     color: #334155;
+}
+
+/* Ensure the toggle button doesn't cover the input */
+#toggle-key-visibility {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: auto;
+    height: auto;
+    z-index: 1;
 }
 
 /* Focus states for accessibility */


### PR DESCRIPTION
## Summary
- refine the activation key input toggle to prevent it from covering the field

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6883c97dc680832496f5dd82616af7fd