### PR TITLE
Fix custom data path UX and add D&D ability options

### DIFF
--- a/js/utils/template-helpers.js
+++ b/js/utils/template-helpers.js
@@ -81,12 +81,21 @@ export function initializeTemplateHelperEvents(html) {
   html.on('change', '.fso-data-path-select', function() {
     const select = $(this);
     const customSection = select.closest('.fso-data-selector').find('.fso-custom-path-section');
-    
+
     if (select.val() === 'custom') {
       customSection.slideDown(200);
       customSection.find('.fso-custom-path-input').focus();
     } else {
       customSection.slideUp(200);
+    }
+  });
+
+  // If a user types in a custom path, automatically switch the dropdown to "custom"
+  html.on('input', '.fso-custom-path-input', function() {
+    const input = $(this);
+    const selector = input.closest('.fso-data-selector').find('.fso-data-path-select');
+    if (selector.val() !== 'custom') {
+      selector.val('custom').trigger('change');
     }
   });
 

--- a/templates/foundrystreamoverlay-config.html
+++ b/templates/foundrystreamoverlay-config.html
@@ -127,6 +127,14 @@
                         <option value="system.attributes.ac.value" {{#ifEquals dataPath "system.attributes.ac.value"}}selected{{/ifEquals}}>Armor Class</option>
                         <option value="system.details.level" {{#ifEquals dataPath "system.details.level"}}selected{{/ifEquals}}>Level</option>
                       </optgroup>
+                      <optgroup label="Ability Scores">
+                        <option value="system.abilities.str.value" {{#ifEquals dataPath "system.abilities.str.value"}}selected{{/ifEquals}}>STR</option>
+                        <option value="system.abilities.dex.value" {{#ifEquals dataPath "system.abilities.dex.value"}}selected{{/ifEquals}}>DEX</option>
+                        <option value="system.abilities.con.value" {{#ifEquals dataPath "system.abilities.con.value"}}selected{{/ifEquals}}>CON</option>
+                        <option value="system.abilities.int.value" {{#ifEquals dataPath "system.abilities.int.value"}}selected{{/ifEquals}}>INT</option>
+                        <option value="system.abilities.wis.value" {{#ifEquals dataPath "system.abilities.wis.value"}}selected{{/ifEquals}}>WIS</option>
+                        <option value="system.abilities.cha.value" {{#ifEquals dataPath "system.abilities.cha.value"}}selected{{/ifEquals}}>CHA</option>
+                      </optgroup>
                       <optgroup label="Advanced">
                         <option value="custom" {{#ifEquals dataPath "custom"}}selected{{/ifEquals}}>Custom Data Path...</option>
                       </optgroup>


### PR DESCRIPTION
## Summary
- add ability score options to the data-path dropdown
- auto-select `Custom Data Path` when the user types in the custom field

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883f752d5d88324b5484d5655d36dfb